### PR TITLE
Enable large exams and fix session resets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+app/cissp.db
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# CISSP
+# CISSP Study Web App
+
+This project provides a small Flask web application to help you practice for the CISSP exam. It supports flashcards, mock exams with per-question feedback, question management, and progress tracking. Questions are stored in an SQLite database so it can run locally without extra services.
+
+## Features
+
+- Random flashcards for quick review
+- Create mock exams with scoring and explanations after each answer
+- Choose which security domains to include when starting an exam
+- Add, edit, or delete questions
+- Track exam results over time
+
+## Setup
+
+1. Create a Python environment (Python 3.8+ recommended).
+2. Install Flask:
+   ```bash
+   pip install Flask
+   ```
+3. Initialize the database:
+   ```bash
+   python app/initialize_db.py
+   ```
+4. (Optional) Import your questions from a JSON file:
+   ```bash
+   python app/import_questions.py questions.json
+   ```
+   A template file `questions.json.template` is included to show the expected format.
+5. Run the application:
+   ```bash
+   python app/app.py
+   ```
+6. Open your browser to `http://localhost:5000`.
+
+Once running, use the **Questions** link in the navigation bar to view all questions.
+From there you can edit or delete entries.
+During an exam you select how many questions to attempt and which domains to draw from. The application now compresses the question list so you can practice hundreds of questions in one sitting. After each answer you will immediately see whether you were correct along with the explanation before moving on.
+
+## Question JSON Format
+
+Each question should include a domain, text, four answer options, the correct option (A/B/C/D) and an optional explanation. Example:
+
+```json
+[
+  {
+    "domain": "Security and Risk Management",
+    "question": "What is the primary purpose of a security policy?",
+    "option_a": "To define technical controls",
+    "option_b": "To outline management's intent",
+    "option_c": "To implement physical security",
+    "option_d": "To configure firewalls",
+    "correct_option": "B",
+    "explanation": "A security policy is a high-level statement of management's intent and goals."
+  }
+]
+```
+
+## Notes
+
+This project is intended for personal study use. If you share questions or other content, ensure that you have the rights to do so.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,215 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+import sqlite3
+from datetime import datetime
+import os
+import json
+import zlib
+import base64
+
+app = Flask(__name__)
+app.secret_key = "cissp-secret-key"
+
+DATABASE = os.path.join(os.path.dirname(__file__), 'cissp.db')
+
+
+def get_db_connection():
+    conn = sqlite3.connect(DATABASE)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def store_question_ids(question_ids):
+    """Compress and store the question ID list in the session."""
+    raw = json.dumps(question_ids).encode()
+    blob = base64.b64encode(zlib.compress(raw)).decode()
+    session['question_blob'] = blob
+
+
+def load_question_ids():
+    """Load and decompress the question ID list from the session."""
+    blob = session.get('question_blob')
+    if not blob:
+        return None
+    try:
+        raw = zlib.decompress(base64.b64decode(blob))
+        return json.loads(raw.decode())
+    except Exception:
+        return None
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/flashcards')
+def flashcards():
+    conn = get_db_connection()
+    cur = conn.execute('SELECT * FROM questions ORDER BY RANDOM() LIMIT 1')
+    question = cur.fetchone()
+    conn.close()
+    return render_template('flashcards.html', question=question)
+
+
+@app.route('/exam', methods=['GET', 'POST'])
+def exam():
+    conn = get_db_connection()
+    cur = conn.execute('SELECT DISTINCT domain FROM questions ORDER BY domain')
+    domains = [row['domain'] for row in cur.fetchall()]
+    if request.method == 'POST':
+        num_q = int(request.form.get('num_questions', 10))
+        selected_domains = request.form.getlist('domains') or domains
+        placeholders = ','.join('?' for _ in selected_domains)
+        query = f'SELECT id FROM questions WHERE domain IN ({placeholders}) ORDER BY RANDOM() LIMIT ?'
+        cur = conn.execute(query, (*selected_domains, num_q))
+        question_ids = [row['id'] for row in cur.fetchall()]
+        conn.close()
+        session.pop('question_blob', None)
+        store_question_ids(question_ids)
+        session['current'] = 0
+        session['score'] = 0
+        return redirect(url_for('take_exam'))
+    conn.close()
+    return render_template('exam.html', domains=domains)
+
+
+@app.route('/take_exam')
+def take_exam():
+    question_ids = load_question_ids()
+    current = session.get('current', 0)
+
+    if not question_ids or current >= len(question_ids):
+        return redirect(url_for('exam'))
+
+    conn = get_db_connection()
+    qid = question_ids[current]
+    question = conn.execute('SELECT * FROM questions WHERE id=?', (qid,)).fetchone()
+    conn.close()
+    return render_template('take_exam.html', question=question, current=current+1, total=len(question_ids))
+
+
+@app.route('/answer_question', methods=['POST'])
+def answer_question():
+    question_ids = load_question_ids()
+    current = session.get('current', 0)
+    score = session.get('score', 0)
+
+    if not question_ids or current >= len(question_ids):
+        return redirect(url_for('exam'))
+
+    selected = request.form.get('answer')
+    conn = get_db_connection()
+    qid = question_ids[current]
+    question = conn.execute('SELECT * FROM questions WHERE id=?', (qid,)).fetchone()
+    correct = selected == question['correct_option']
+    if correct:
+        score += 1
+    session['score'] = score
+    session['current'] = current + 1
+    session['last_question_id'] = qid
+    session['last_selected'] = selected
+
+    done = session['current'] >= len(question_ids)
+    if done:
+        conn.execute('INSERT INTO results (date, score, total) VALUES (?, ?, ?)',
+                     (datetime.utcnow(), score, len(question_ids)))
+        conn.commit()
+    conn.close()
+
+    return redirect(url_for('review_question'))
+
+
+@app.route('/review_question')
+def review_question():
+    qid = session.get('last_question_id')
+    selected = session.get('last_selected')
+    question_ids = load_question_ids()
+    current = session.get('current', 0)
+
+    if qid is None or question_ids is None:
+        return redirect(url_for('exam'))
+
+    conn = get_db_connection()
+    question = conn.execute('SELECT * FROM questions WHERE id=?', (qid,)).fetchone()
+    conn.close()
+    correct = selected == question['correct_option']
+    done = current >= len(question_ids)
+    next_url = url_for('exam_result') if done else url_for('take_exam')
+    return render_template('review_question.html', question=question, selected=selected,
+                           correct=correct, next_url=next_url,
+                           current=current, total=len(question_ids))
+
+
+@app.route('/exam_result')
+def exam_result():
+    score = session.get('score', 0)
+    question_ids = load_question_ids() or []
+    session.pop('question_blob', None)
+    total = len(question_ids)
+    return render_template('exam_result.html', score=score, total=total)
+
+
+@app.route('/progress')
+def progress():
+    conn = get_db_connection()
+    cur = conn.execute('SELECT * FROM results ORDER BY date DESC')
+    results = cur.fetchall()
+    conn.close()
+    return render_template('progress.html', results=results)
+
+
+@app.route('/questions')
+def question_list():
+    """Display all questions for editing or deletion."""
+    conn = get_db_connection()
+    cur = conn.execute('SELECT id, domain, question FROM questions ORDER BY id ASC')
+    questions = cur.fetchall()
+    conn.close()
+    return render_template('question_list.html', questions=questions)
+
+
+@app.route('/question/delete/<int:question_id>', methods=['POST'])
+def delete_question(question_id):
+    conn = get_db_connection()
+    conn.execute('DELETE FROM questions WHERE id=?', (question_id,))
+    conn.commit()
+    conn.close()
+    return redirect(url_for('question_list'))
+
+
+@app.route('/question/new', methods=['GET', 'POST'])
+@app.route('/question/<int:question_id>', methods=['GET', 'POST'])
+def question_form(question_id=None):
+    conn = get_db_connection()
+    if request.method == 'POST':
+        data = (
+            request.form['domain'],
+            request.form['question'],
+            request.form['option_a'],
+            request.form['option_b'],
+            request.form['option_c'],
+            request.form['option_d'],
+            request.form['correct_option'],
+            request.form.get('explanation', '')
+        )
+        if question_id:
+            conn.execute('''UPDATE questions SET domain=?, question=?, option_a=?, option_b=?,
+                            option_c=?, option_d=?, correct_option=?, explanation=? WHERE id=?''',
+                         data + (question_id,))
+        else:
+            conn.execute('''INSERT INTO questions (domain, question, option_a, option_b,
+                            option_c, option_d, correct_option, explanation)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?)''', data)
+        conn.commit()
+        conn.close()
+        return redirect(url_for('index'))
+    question = None
+    if question_id:
+        cur = conn.execute('SELECT * FROM questions WHERE id=?', (question_id,))
+        question = cur.fetchone()
+    conn.close()
+    return render_template('question_form.html', question=question)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/import_questions.py
+++ b/app/import_questions.py
@@ -1,0 +1,26 @@
+import json
+import sqlite3
+import os
+import sys
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'cissp.db')
+
+if len(sys.argv) < 2:
+    print('Usage: python import_questions.py questions.json')
+    sys.exit(1)
+
+json_file = sys.argv[1]
+
+with open(json_file, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+
+conn = sqlite3.connect(DB_PATH)
+for q in data:
+    conn.execute('''INSERT INTO questions
+                    (domain, question, option_a, option_b, option_c, option_d, correct_option, explanation)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+                 (q['domain'], q['question'], q['option_a'], q['option_b'],
+                  q['option_c'], q['option_d'], q['correct_option'], q.get('explanation', '')))
+conn.commit()
+conn.close()
+print('Imported', len(data), 'questions.')

--- a/app/initialize_db.py
+++ b/app/initialize_db.py
@@ -1,0 +1,31 @@
+import sqlite3
+import os
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'cissp.db')
+
+schema = '''
+CREATE TABLE IF NOT EXISTS questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    question TEXT NOT NULL,
+    option_a TEXT NOT NULL,
+    option_b TEXT NOT NULL,
+    option_c TEXT NOT NULL,
+    option_d TEXT NOT NULL,
+    correct_option TEXT NOT NULL,
+    explanation TEXT
+);
+
+CREATE TABLE IF NOT EXISTS results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date TEXT NOT NULL,
+    score INTEGER NOT NULL,
+    total INTEGER NOT NULL
+);
+'''
+
+conn = sqlite3.connect(DB_PATH)
+conn.executescript(schema)
+conn.commit()
+conn.close()
+print('Database initialized at', DB_PATH)

--- a/app/templates/exam.html
+++ b/app/templates/exam.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Start Exam</h2>
+<form method="post">
+    <div class="mb-3">
+        <label for="num_questions" class="form-label">Number of Questions</label>
+        <input type="number" class="form-control" id="num_questions" name="num_questions" value="10" min="1" max="1000">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Domains to Include</label>
+        {% for d in domains %}
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="domains" id="dom{{ loop.index }}" value="{{ d }}" checked>
+            <label class="form-check-label" for="dom{{ loop.index }}">{{ d }}</label>
+        </div>
+        {% endfor %}
+    </div>
+    <button type="submit" class="btn btn-primary">Begin</button>
+</form>
+{% endblock %}

--- a/app/templates/exam_result.html
+++ b/app/templates/exam_result.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Exam Completed</h2>
+<p>Your score: {{ score }} / {{ total }}</p>
+<a class="btn btn-primary" href="{{ url_for('exam') }}">Take Another Exam</a>
+{% endblock %}

--- a/app/templates/flashcards.html
+++ b/app/templates/flashcards.html
@@ -1,0 +1,24 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Flashcard</h2>
+<div class="card">
+    <div class="card-body">
+        <p><strong>Domain:</strong> {{ question['domain'] }}</p>
+        <p>{{ question['question'] }}</p>
+        <details>
+            <summary>Show Answer</summary>
+            <ul>
+                <li>A. {{ question['option_a'] }}</li>
+                <li>B. {{ question['option_b'] }}</li>
+                <li>C. {{ question['option_c'] }}</li>
+                <li>D. {{ question['option_d'] }}</li>
+            </ul>
+            <p>Correct: {{ question['correct_option'] }}</p>
+            {% if question['explanation'] %}
+            <p>{{ question['explanation'] }}</p>
+            {% endif %}
+        </details>
+    </div>
+</div>
+<a class="btn btn-primary mt-3" href="{{ url_for('flashcards') }}">Next</a>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Welcome to the CISSP Study App</h1>
+<p>Use this tool to practice questions and review flashcards for the CISSP exam.</p>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CISSP Study App</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">CISSP Study</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('flashcards') }}">Flashcards</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('exam') }}">Exam</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('progress') }}">Progress</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('question_list') }}">Questions</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Exam Progress</h2>
+<table class="table">
+    <thead>
+        <tr><th>Date</th><th>Score</th></tr>
+    </thead>
+    <tbody>
+    {% for r in results %}
+        <tr><td>{{ r['date'] }}</td><td>{{ r['score'] }}/{{ r['total'] }}</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/app/templates/question_form.html
+++ b/app/templates/question_form.html
@@ -1,0 +1,39 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{% if question %}Edit{% else %}New{% endif %} Question</h2>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Domain</label>
+        <input type="text" name="domain" class="form-control" value="{{ question['domain'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Question</label>
+        <textarea name="question" class="form-control" required>{{ question['question'] if question else '' }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Option A</label>
+        <input type="text" name="option_a" class="form-control" value="{{ question['option_a'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Option B</label>
+        <input type="text" name="option_b" class="form-control" value="{{ question['option_b'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Option C</label>
+        <input type="text" name="option_c" class="form-control" value="{{ question['option_c'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Option D</label>
+        <input type="text" name="option_d" class="form-control" value="{{ question['option_d'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Correct Option (A/B/C/D)</label>
+        <input type="text" name="correct_option" class="form-control" value="{{ question['correct_option'] if question else '' }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Explanation (optional)</label>
+        <textarea name="explanation" class="form-control">{{ question['explanation'] if question else '' }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/question_list.html
+++ b/app/templates/question_list.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Questions</h2>
+<table class="table table-striped">
+    <thead>
+        <tr><th>ID</th><th>Domain</th><th>Question</th><th></th></tr>
+    </thead>
+    <tbody>
+    {% for q in questions %}
+        <tr>
+            <td>{{ q['id'] }}</td>
+            <td>{{ q['domain'] }}</td>
+            <td>{{ q['question']|truncate(80) }}</td>
+            <td>
+                <a class="btn btn-sm btn-secondary" href="{{ url_for('question_form', question_id=q['id']) }}">Edit</a>
+                <form method="post" action="{{ url_for('delete_question', question_id=q['id']) }}" style="display:inline-block" onsubmit="return confirm('Delete this question?');">
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+<a class="btn btn-primary" href="{{ url_for('question_form') }}">Add Question</a>
+{% endblock %}

--- a/app/templates/review_question.html
+++ b/app/templates/review_question.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Question {{ current }} of {{ total }}</h2>
+<p><strong>Domain:</strong> {{ question['domain'] }}</p>
+<p>{{ question['question'] }}</p>
+<ul>
+    <li>A. {{ question['option_a'] }}</li>
+    <li>B. {{ question['option_b'] }}</li>
+    <li>C. {{ question['option_c'] }}</li>
+    <li>D. {{ question['option_d'] }}</li>
+</ul>
+<p class="mt-2 fw-bold">
+{% if correct %}Correct!{% else %}Wrong.{% endif %}
+Selected: {{ selected }} &mdash; Correct: {{ question['correct_option'] }}
+</p>
+{% if question['explanation'] %}
+<p>{{ question['explanation'] }}</p>
+{% endif %}
+<a class="btn btn-primary" href="{{ next_url }}">Next</a>
+{% endblock %}

--- a/app/templates/take_exam.html
+++ b/app/templates/take_exam.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Question {{ current }} of {{ total }}</h2>
+<form method="post" action="{{ url_for('answer_question') }}">
+    <p><strong>Domain:</strong> {{ question['domain'] }}</p>
+    <p>{{ question['question'] }}</p>
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="answer" id="a" value="A" required>
+        <label class="form-check-label" for="a">A. {{ question['option_a'] }}</label>
+    </div>
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="answer" id="b" value="B">
+        <label class="form-check-label" for="b">B. {{ question['option_b'] }}</label>
+    </div>
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="answer" id="c" value="C">
+        <label class="form-check-label" for="c">C. {{ question['option_c'] }}</label>
+    </div>
+    <div class="form-check">
+        <input class="form-check-input" type="radio" name="answer" id="d" value="D">
+        <label class="form-check-label" for="d">D. {{ question['option_d'] }}</label>
+    </div>
+    <button type="submit" class="btn btn-primary mt-3">Next</button>
+</form>
+{% endblock %}

--- a/questions.json.template
+++ b/questions.json.template
@@ -1,0 +1,12 @@
+[
+    {
+        "domain": "Security and Risk Management",
+        "question": "What is the primary purpose of a security policy?",
+        "option_a": "To define technical controls",
+        "option_b": "To outline management's intent",
+        "option_c": "To implement physical security",
+        "option_d": "To configure firewalls",
+        "correct_option": "B",
+        "explanation": "A security policy is a high-level statement of management's intent and goals."
+    }
+]


### PR DESCRIPTION
## Summary
- compress question lists in the session so exams can include hundreds of questions
- clear previous exam data when starting a new exam
- allow specifying up to 1000 questions on the exam setup page
- mention large exam capability in the README

## Testing
- `python -m py_compile app/app.py app/initialize_db.py app/import_questions.py`
- `python app/initialize_db.py`
- `python app/import_questions.py questions.json.template`


------
https://chatgpt.com/codex/tasks/task_e_6850014105ec8331979b39d18a5e4803